### PR TITLE
Use fully-qualified path when importing cmd package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cloud-key-rotator/cmd"
+	"github.com/ovotech/cloud-key-rotator/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Think this is the convention to allow the build tool to find sub-packages.  I was unable to compile / run main.go locally without this change.  Had a look at the CRM package structure and they've followed this approach.