### PR TITLE
Add functionality for AWS creds to be written to GitHub locations

### DIFF
--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -11,11 +11,11 @@ import (
 
 //EncryptedServiceAccountKey uses github.com/ovotech/mantle to encrypt the
 // key string that's passed in
-func EncryptedServiceAccountKey(key, kmsKey string) (encKey []byte, err error) {
+func EncryptedServiceAccountKey(key, kmsKey string) (encKey []byte) {
 	const singleLine = false
 	const disableValidation = true
 	return enc.CipherBytesFromPrimitives([]byte(key), singleLine,
-		disableValidation, "", "", "", "", kmsKey), nil
+		disableValidation, "", "", "", "", kmsKey)
 }
 
 //CommitSignKey creates an openPGP Entity based on a user's name, email,

--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -1,7 +1,6 @@
 package crypt
 
 import (
-	b64 "encoding/base64"
 	"errors"
 	"os"
 	"strings"
@@ -12,20 +11,10 @@ import (
 
 //EncryptedServiceAccountKey uses github.com/ovotech/mantle to encrypt the
 // key string that's passed in
-func EncryptedServiceAccountKey(key, kmsKey string, base64Decode bool) (encKey []byte, err error) {
+func EncryptedServiceAccountKey(key, kmsKey string) (encKey []byte, err error) {
 	const singleLine = false
 	const disableValidation = true
-
-	var decodedKey []byte
-	if base64Decode {
-		if decodedKey, err = b64.StdEncoding.DecodeString(key); err != nil {
-			return
-		}
-	} else {
-		decodedKey = []byte(key)
-	}
-
-	return enc.CipherBytesFromPrimitives([]byte(decodedKey), singleLine,
+	return enc.CipherBytesFromPrimitives([]byte(key), singleLine,
 		disableValidation, "", "", "", "", kmsKey), nil
 }
 

--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -12,13 +12,17 @@ import (
 
 //EncryptedServiceAccountKey uses github.com/ovotech/mantle to encrypt the
 // key string that's passed in
-func EncryptedServiceAccountKey(key, kmsKey string) (encKey []byte, err error) {
+func EncryptedServiceAccountKey(key, kmsKey string, base64Decode bool) (encKey []byte, err error) {
 	const singleLine = false
 	const disableValidation = true
 
 	var decodedKey []byte
-	if decodedKey, err = b64.StdEncoding.DecodeString(key); err != nil {
-		return
+	if base64Decode {
+		if decodedKey, err = b64.StdEncoding.DecodeString(key); err != nil {
+			return
+		}
+	} else {
+		decodedKey = []byte(key)
 	}
 
 	return enc.CipherBytesFromPrimitives([]byte(decodedKey), singleLine,

--- a/pkg/location/circleci.go
+++ b/pkg/location/circleci.go
@@ -21,7 +21,7 @@ var logger = log.StdoutLogger().Sugar()
 
 //updateCircleCI updates the circleCI environment variable by deleting and
 //then creating it again with the new key
-func (circle CircleCI) Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (circle CircleCI) Write(serviceAccountName string, keyWrapper KeyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
 	logger.Info("Starting CircleCI env var updates")
 	client := &circleci.Client{Token: creds.CircleCIAPIToken}
 	keyIDEnvVarName := circle.KeyIDEnvVar
@@ -30,12 +30,12 @@ func (circle CircleCI) Write(serviceAccountName, keyWrapper keyWrapper, creds cr
 	project := splitUsernameProject[1]
 
 	if len(keyIDEnvVarName) > 0 {
-		if err = updateCircleCIEnvVar(username, project, keyIDEnvVarName, keyWrapper.keyID, client); err != nil {
+		if err = updateCircleCIEnvVar(username, project, keyIDEnvVarName, keyWrapper.KeyID, client); err != nil {
 			return
 		}
 	}
 
-	if err = updateCircleCIEnvVar(username, project, circle.KeyEnvVar, keyWrapper.key, client); err != nil {
+	if err = updateCircleCIEnvVar(username, project, circle.KeyEnvVar, keyWrapper.Key, client); err != nil {
 		return
 	}
 

--- a/pkg/location/circleci.go
+++ b/pkg/location/circleci.go
@@ -21,7 +21,7 @@ var logger = log.StdoutLogger().Sugar()
 
 //updateCircleCI updates the circleCI environment variable by deleting and
 //then creating it again with the new key
-func (circle CircleCI) Write(serviceAccountName, keyID, key string, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (circle CircleCI) Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (updated UpdatedLocation, err error) {
 	logger.Info("Starting CircleCI env var updates")
 	client := &circleci.Client{Token: creds.CircleCIAPIToken}
 	keyIDEnvVarName := circle.KeyIDEnvVar

--- a/pkg/location/circleci.go
+++ b/pkg/location/circleci.go
@@ -21,7 +21,7 @@ var logger = log.StdoutLogger().Sugar()
 
 //updateCircleCI updates the circleCI environment variable by deleting and
 //then creating it again with the new key
-func (circle CircleCI) Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (circle CircleCI) Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
 	logger.Info("Starting CircleCI env var updates")
 	client := &circleci.Client{Token: creds.CircleCIAPIToken}
 	keyIDEnvVarName := circle.KeyIDEnvVar
@@ -30,12 +30,12 @@ func (circle CircleCI) Write(serviceAccountName, keyID, key, keyProvider string,
 	project := splitUsernameProject[1]
 
 	if len(keyIDEnvVarName) > 0 {
-		if err = updateCircleCIEnvVar(username, project, keyIDEnvVarName, keyID, client); err != nil {
+		if err = updateCircleCIEnvVar(username, project, keyIDEnvVarName, keyWrapper.keyID, client); err != nil {
 			return
 		}
 	}
 
-	if err = updateCircleCIEnvVar(username, project, circle.KeyEnvVar, key, client); err != nil {
+	if err = updateCircleCIEnvVar(username, project, circle.KeyEnvVar, keyWrapper.key, client); err != nil {
 		return
 	}
 

--- a/pkg/location/github.go
+++ b/pkg/location/github.go
@@ -25,7 +25,7 @@ type GitHub struct {
 	CircleCIDeployJobName string
 }
 
-func (gitHub GitHub) Write(serviceAccountName, keyID, key string, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (gitHub GitHub) Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (updated UpdatedLocation, err error) {
 
 	if len(creds.KmsKey) == 0 {
 		err = errors.New("Not updating un-encrypted new key in a Git repository. Use the" +
@@ -33,7 +33,7 @@ func (gitHub GitHub) Write(serviceAccountName, keyID, key string, creds cred.Cre
 		return
 	}
 	var base64Decode bool
-	if len(keyID) > 0 {
+	if keyProvider == "aws" {
 		key = fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s", keyID, key)
 	} else {
 		base64Decode = true

--- a/pkg/location/github.go
+++ b/pkg/location/github.go
@@ -1,6 +1,7 @@
 package location
 
 import (
+	b64 "encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -33,6 +34,7 @@ func (gitHub GitHub) Write(serviceAccountName, keyWrapper keyWrapper, creds cred
 		return
 	}
 	var base64Decode bool
+	var key string
 	if keyWrapper.keyProvider == "aws" {
 		key = fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s", keyWrapper.keyID, keyWrapper.key)
 	} else {

--- a/pkg/location/github.go
+++ b/pkg/location/github.go
@@ -32,8 +32,12 @@ func (gitHub GitHub) Write(serviceAccountName, keyID, key string, creds cred.Cre
 			"'KmsKey' field in config to specify the KMS key to use for encryption")
 		return
 	}
-
-	// const localDir = "/etc/cloud-key-rotator/cloud-key-rotator-tmp-repo"
+	var base64Decode bool
+	if len(keyID) > 0 {
+		key = fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s", keyID, key)
+	} else {
+		base64Decode = true
+	}
 
 	const localDir = "/etc/cloud-key-rotator/cloud-key-rotator-tmp-repo"
 
@@ -41,7 +45,7 @@ func (gitHub GitHub) Write(serviceAccountName, keyID, key string, creds cred.Cre
 
 	// TODO Move me out of git-specific code
 	var encKey []byte
-	if encKey, err = crypt.EncryptedServiceAccountKey(key, creds.KmsKey); err != nil {
+	if encKey, err = crypt.EncryptedServiceAccountKey(key, creds.KmsKey, base64Decode); err != nil {
 		return
 	}
 

--- a/pkg/location/github.go
+++ b/pkg/location/github.go
@@ -26,20 +26,20 @@ type GitHub struct {
 	CircleCIDeployJobName string
 }
 
-func (gitHub GitHub) Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (gitHub GitHub) Write(serviceAccountName string, keyWrapper KeyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
 
 	if len(creds.KmsKey) == 0 {
 		err = errors.New("Not updating un-encrypted new key in a Git repository. Use the" +
 			"'KmsKey' field in config to specify the KMS key to use for encryption")
 		return
 	}
-	var base64Decode bool
 	var key string
-	if keyWrapper.keyProvider == "aws" {
-		key = fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s", keyWrapper.keyID, keyWrapper.key)
+	if keyWrapper.KeyProvider == "aws" {
+		key = fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s", keyWrapper.KeyID, keyWrapper.Key)
 	} else {
-		if key, err = b64.StdEncoding.DecodeString(keyWrapper.key); err != nil {
-			return
+		var keyBytes []byte
+		if keyBytes, err = b64.StdEncoding.DecodeString(keyWrapper.Key); err == nil {
+			key = string(keyBytes)
 		}
 	}
 

--- a/pkg/location/k8s.go
+++ b/pkg/location/k8s.go
@@ -48,7 +48,7 @@ func init() {
 	}
 }
 
-func (k8s K8s) Write(serviceAccountName, keyID, key string, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (k8s K8s) Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (updated UpdatedLocation, err error) {
 	var cluster *gkev1.Cluster
 
 	if cluster, err = gkeCluster(k8s.Project, k8s.Location, k8s.ClusterName); err != nil {

--- a/pkg/location/k8s.go
+++ b/pkg/location/k8s.go
@@ -48,7 +48,7 @@ func init() {
 	}
 }
 
-func (k8s K8s) Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (k8s K8s) Write(serviceAccountName string, keyWrapper KeyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
 	var cluster *gkev1.Cluster
 
 	if cluster, err = gkeCluster(k8s.Project, k8s.Location, k8s.ClusterName); err != nil {
@@ -60,7 +60,7 @@ func (k8s K8s) Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Crede
 		return
 	}
 
-	if _, err = updateK8sSecret(k8s.SecretName, k8s.DataName, k8s.Namespace, keyWrapper.key, k8sClient); err != nil {
+	if _, err = updateK8sSecret(k8s.SecretName, k8s.DataName, k8s.Namespace, keyWrapper.Key, k8sClient); err != nil {
 		return
 	}
 

--- a/pkg/location/k8s.go
+++ b/pkg/location/k8s.go
@@ -48,7 +48,7 @@ func init() {
 	}
 }
 
-func (k8s K8s) Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (updated UpdatedLocation, err error) {
+func (k8s K8s) Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (updated UpdatedLocation, err error) {
 	var cluster *gkev1.Cluster
 
 	if cluster, err = gkeCluster(k8s.Project, k8s.Location, k8s.ClusterName); err != nil {
@@ -60,7 +60,7 @@ func (k8s K8s) Write(serviceAccountName, keyID, key, keyProvider string, creds c
 		return
 	}
 
-	if _, err = updateK8sSecret(k8s.SecretName, k8s.DataName, k8s.Namespace, key, k8sClient); err != nil {
+	if _, err = updateK8sSecret(k8s.SecretName, k8s.DataName, k8s.Namespace, keyWrapper.key, k8sClient); err != nil {
 		return
 	}
 

--- a/pkg/location/keywriter.go
+++ b/pkg/location/keywriter.go
@@ -5,5 +5,5 @@ import "github.com/ovotech/cloud-key-rotator/pkg/cred"
 
 //KeyWriter interface
 type KeyWriter interface {
-	Write(serviceAccountName, keyID, key string, creds cred.Credentials) (UpdatedLocation, error)
+	Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (UpdatedLocation, error)
 }

--- a/pkg/location/keywriter.go
+++ b/pkg/location/keywriter.go
@@ -5,5 +5,5 @@ import "github.com/ovotech/cloud-key-rotator/pkg/cred"
 
 //KeyWriter interface
 type KeyWriter interface {
-	Write(serviceAccountName, keyID, key, keyProvider string, creds cred.Credentials) (UpdatedLocation, error)
+	Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (UpdatedLocation, error)
 }

--- a/pkg/location/keywriter.go
+++ b/pkg/location/keywriter.go
@@ -5,5 +5,5 @@ import "github.com/ovotech/cloud-key-rotator/pkg/cred"
 
 //KeyWriter interface
 type KeyWriter interface {
-	Write(serviceAccountName, keyWrapper keyWrapper, creds cred.Credentials) (UpdatedLocation, error)
+	Write(serviceAccountName string, keyWrapper KeyWrapper, creds cred.Credentials) (UpdatedLocation, error)
 }

--- a/pkg/location/locations.go
+++ b/pkg/location/locations.go
@@ -7,9 +7,9 @@ type UpdatedLocation struct {
 	LocationIDs  []string
 }
 
-//keyWrapper type
-type keyWrapper struct {
-	key         string
-	keyID       string
-	keyProvider string
+//KeyWrapper type
+type KeyWrapper struct {
+	Key         string
+	KeyID       string
+	KeyProvider string
 }

--- a/pkg/location/locations.go
+++ b/pkg/location/locations.go
@@ -6,3 +6,10 @@ type UpdatedLocation struct {
 	LocationURI  string
 	LocationIDs  []string
 }
+
+//keyWrapper type
+type keyWrapper struct {
+	key         string
+	keyID       string
+	keyProvider string
+}

--- a/pkg/rotate/rotatekeys.go
+++ b/pkg/rotate/rotatekeys.go
@@ -105,7 +105,7 @@ func rotateKey(account string, rotationCandidate rotationCandidate, creds cred.C
 	if newKeyID, newKey, err = createKey(account, key, keyProvider); err != nil {
 		return
 	}
-	keyWrapper := location.keyWrapper{newKey, newKeyID, keyProvider}
+	keyWrapper := location.KeyWrapper{newKey, newKeyID, keyProvider}
 	if err = updateKeyLocation(account, rotationCandidate.keyLocation, keyWrapper, creds); err != nil {
 		return
 	}
@@ -239,7 +239,7 @@ func locationsToUpdate(keyLocation config.KeyLocations) (kws []location.KeyWrite
 
 //updateKeyLocation updates locations specified in keyLocations with the new key, e.g. GitHub, CircleCI an K8s
 func updateKeyLocation(account string, keyLocations config.KeyLocations,
-	keyWrapper location.keyWrapper, creds cred.Credentials) (err error) {
+	keyWrapper location.KeyWrapper, creds cred.Credentials) (err error) {
 
 	// update locations
 	var updatedLocations []location.UpdatedLocation
@@ -257,9 +257,9 @@ func updateKeyLocation(account string, keyLocations config.KeyLocations,
 
 	// all done
 	logger.Infow("Key locations updated",
-		"keyProvider", keyProvider,
+		"keyProvider", keyWrapper.KeyProvider,
 		"account", account,
-		"keyID", keyID,
+		"keyID", keyWrapper.KeyID,
 		"keyLocationUpdates", updatedLocations)
 
 	return

--- a/pkg/rotate/rotatekeys.go
+++ b/pkg/rotate/rotatekeys.go
@@ -25,12 +25,6 @@ type rotationCandidate struct {
 	rotationThresholdMins int
 }
 
-type keyWrapper struct {
-	key         string
-	keyID       string
-	keyProvider string
-}
-
 var logger = log.StdoutLogger().Sugar()
 
 const (
@@ -111,7 +105,7 @@ func rotateKey(account string, rotationCandidate rotationCandidate, creds cred.C
 	if newKeyID, newKey, err = createKey(account, key, keyProvider); err != nil {
 		return
 	}
-	keyWrapper := keyWrapper{newKey, newKeyID, keyProvider}
+	keyWrapper := location.keyWrapper{newKey, newKeyID, keyProvider}
 	if err = updateKeyLocation(account, rotationCandidate.keyLocation, keyWrapper, creds); err != nil {
 		return
 	}
@@ -244,7 +238,8 @@ func locationsToUpdate(keyLocation config.KeyLocations) (kws []location.KeyWrite
 }
 
 //updateKeyLocation updates locations specified in keyLocations with the new key, e.g. GitHub, CircleCI an K8s
-func updateKeyLocation(account string, keyLocations config.KeyLocations, keyWrapper keyWrapper, creds cred.Credentials) (err error) {
+func updateKeyLocation(account string, keyLocations config.KeyLocations,
+	keyWrapper location.keyWrapper, creds cred.Credentials) (err error) {
 
 	// update locations
 	var updatedLocations []location.UpdatedLocation

--- a/pkg/rotate/rotatekeys.go
+++ b/pkg/rotate/rotatekeys.go
@@ -246,7 +246,7 @@ func updateKeyLocation(account string, keyLocations config.KeyLocations, keyID, 
 
 		var updated location.UpdatedLocation
 
-		if updated, err = locationToUpdate.Write(keyLocations.ServiceAccountName, keyID, key, creds); err != nil {
+		if updated, err = locationToUpdate.Write(keyLocations.ServiceAccountName, keyID, key, keyProvider, creds); err != nil {
 			return
 		}
 

--- a/pkg/rotate/rotatekeys.go
+++ b/pkg/rotate/rotatekeys.go
@@ -105,7 +105,7 @@ func rotateKey(account string, rotationCandidate rotationCandidate, creds cred.C
 	if newKeyID, newKey, err = createKey(account, key, keyProvider); err != nil {
 		return
 	}
-	keyWrapper := location.KeyWrapper{newKey, newKeyID, keyProvider}
+	keyWrapper := location.KeyWrapper{Key: newKey, KeyID: newKeyID, KeyProvider: keyProvider}
 	if err = updateKeyLocation(account, rotationCandidate.keyLocation, keyWrapper, creds); err != nil {
 		return
 	}


### PR DESCRIPTION
Added a `base64Decode` bool to handle decoding (or not) when dealing with GCP keys (which are given back to us already encoded), and AWS key data sets which aren't encoded.