### PR TITLE
WIP Change TF module to deploy on merge to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,12 +149,6 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
             branches:
               ignore: /.*/
-      - publish_tf_module:
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-            branches:
-              ignore: /.*/
   pr_pipeline:
     jobs:
       - go_fmt:
@@ -204,6 +198,10 @@ workflows:
             branches:
               only: master
       - go_test:
+          filters:
+            branches:
+              only: master
+      - publish_tf_module:
           filters:
             branches:
               only: master


### PR DESCRIPTION
Still need to make sure that terraform knows the binary has changed on update: https://www.terraform.io/docs/providers/aws/r/lambda_function.html#source_code_hash perhaps?

Can we find a way to set the latest binary version name as a default in a variable?