### PR TITLE
Post metrics to datadog after rotation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,6 +60,8 @@ If you add a Datadog struct to the config, you can get `cloud-key-rotator` to po
   "DatadogAPIKey": "okj23434poz3j4o324p455oz3j4o324",
 ```
 
+All the fields in the DataDog struct are required.
+
 ### Authentication
 
 Regardless of where you run the `cloud-key-rotator` application, you'll need

--- a/pkg/rotate/rotatekeys.go
+++ b/pkg/rotate/rotatekeys.go
@@ -104,11 +104,10 @@ func Rotate(account, provider, project string, c config.Config) (err error) {
 	}
 	logger.Infof("Filtered down to %d keys based on current app config", len(providerKeys))
 	if !c.RotationMode {
-		// Don't call isDatadogSet to maintain backwards compatibility
-		// Previously users have been permitted to send metrics to datadog with
-		// Datadog config structs that do not set the MetricName field
-		if metricErr := postMetric(providerKeys, c.DatadogAPIKey, c.Datadog); metricErr != nil {
-			logger.Infow("Posting metrics errored", metricErr)
+		if isDatadogKeySet(c.DatadogAPIKey) {
+			if metricErr := postMetric(providerKeys, c.DatadogAPIKey, c.Datadog); metricErr != nil {
+				logger.Infow("Posting metrics errored", metricErr)
+			}
 		}
 		if c.EnableKeyAgeLogging {
 			obfuscatedKeys := []keys.Key{}
@@ -143,7 +142,7 @@ func Rotate(account, provider, project string, c config.Config) (err error) {
 	if err = rotateKeys(rc, c.Credentials); err != nil {
 		return
 	}
-	if isDatadogSet(c.Datadog) {
+	if isDatadogKeySet(c.DatadogAPIKey) {
 		// Refresh key ages post rotation
 		if providerKeys, err = keysOfProviders(account, provider, project, c); err != nil {
 			return
@@ -153,7 +152,7 @@ func Rotate(account, provider, project string, c config.Config) (err error) {
 	return
 }
 
-//rotatekey creates a new key for the rotation candidate, updates its key locations,
+//rotateKey creates a new key for the rotation candidate, updates its key locations,
 // and deletes the old key iff the key location update is successful
 func rotateKey(rotationCandidate rotationCandidate, creds cred.Credentials) (err error) {
 	key := rotationCandidate.key
@@ -510,46 +509,43 @@ func validAwsKey(key keys.Key, config config.Config) (valid bool) {
 	return
 }
 
-func isDatadogSet(datadog config.Datadog) bool {
-	// If no metric name has been set, we assume the datadog config struct is not in use
-	return datadog.MetricName != ""
+func isDatadogKeySet(apiKey string) bool {
+	return len(apiKey) > 0
 }
 
 //postMetric posts details of each keys.Key to a metrics api
 func postMetric(keys []keys.Key, apiKey string, datadog config.Datadog) (err error) {
-	if len(apiKey) > 0 {
-		url := strings.Join([]string{datadogURL, apiKey}, "")
-		for _, key := range keys {
-			var jsonString = []byte(
-				`{ "series" :[{"metric":"` + datadog.MetricName + `",` +
-					`"points":[[` +
-					strconv.FormatInt(time.Now().Unix(), 10) +
-					`, ` + strconv.FormatFloat(key.Age, 'f', 2, 64) +
-					`]],` +
-					`"type":"count",` +
-					`"tags":[` +
-					`"team:` + datadog.MetricTeam + `",` +
-					`"project:` + datadog.MetricProject + `",` +
-					`"environment:` + datadog.MetricEnv + `",` +
-					`"key:` + key.Name + `",` +
-					`"provider:` + key.Provider.Provider + `",` +
-					`"status:` + key.Status + `",` +
-					`"account:` + key.Account +
-					`"]}]}`)
-			var req *http.Request
-			if req, err = http.NewRequest("POST", url, bytes.NewBuffer(jsonString)); err != nil {
-				return
-			}
-			req.Header.Set("Content-type", "application/json")
-			client := &http.Client{}
-			var resp *http.Response
-			if resp, err = client.Do(req); err != nil {
-				return
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != 202 {
-				err = fmt.Errorf("non-202 status code (%d) returned by Datadog", resp.StatusCode)
-			}
+	url := strings.Join([]string{datadogURL, apiKey}, "")
+	for _, key := range keys {
+		var jsonString = []byte(
+			`{ "series" :[{"metric":"` + datadog.MetricName + `",` +
+				`"points":[[` +
+				strconv.FormatInt(time.Now().Unix(), 10) +
+				`, ` + strconv.FormatFloat(key.Age, 'f', 2, 64) +
+				`]],` +
+				`"type":"count",` +
+				`"tags":[` +
+				`"team:` + datadog.MetricTeam + `",` +
+				`"project:` + datadog.MetricProject + `",` +
+				`"environment:` + datadog.MetricEnv + `",` +
+				`"key:` + key.Name + `",` +
+				`"provider:` + key.Provider.Provider + `",` +
+				`"status:` + key.Status + `",` +
+				`"account:` + key.Account +
+				`"]}]}`)
+		var req *http.Request
+		if req, err = http.NewRequest("POST", url, bytes.NewBuffer(jsonString)); err != nil {
+			return
+		}
+		req.Header.Set("Content-type", "application/json")
+		client := &http.Client{}
+		var resp *http.Response
+		if resp, err = client.Do(req); err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 202 {
+			err = fmt.Errorf("non-202 status code (%d) returned by Datadog", resp.StatusCode)
 		}
 	}
 	return


### PR DESCRIPTION
This adds code to post metrics to datadog after rotation.

It also logs errors from posting metrics in non-rotation mode. I'm on the fence about whether this is a good idea, as the current behaviour will call datadog even when the user hasn't set a metric name or authenticated, so this could make some people's implementations noisier. It still seems better to let them know what's going wrong, though.