### PR TITLE
Add error handling for GCS viper config read

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,7 +144,9 @@ func GetConfigFromGCS(bucketName, objectName, configType string) (c Config, err 
 		return
 	}
 	viper.SetConfigType(configType)
-	viper.ReadConfig(bytes.NewReader(data))
+	if err = viper.ReadConfig(bytes.NewReader(data)); err != nil {
+		return
+	}
 	err = viper.Unmarshal(&c)
 	return
 }


### PR DESCRIPTION
fixes #269 

the error wasn't being returned by `viper.Unmarshal(&c)` as I first thought, rather from `viper.ReadConfig(bytes.NewReader(data))` instead, so this change just checks the `err` and returns early if not nil