### PR TITLE
Unhardcodes region in aws module

### DIFF
--- a/tf_module/README.md
+++ b/tf_module/README.md
@@ -44,6 +44,7 @@ module "cloud-key-rotator" {
 * (Optional) `config_data = <string>` -> Pass a json blob from any source containing your config file.
 * (Optional) `enable_ssm_location = false` -> Whether to create an IAM policy allowing `ssm:PutParameter`.
 Set this to `true` if using SSM as a `cloud-key-rotator` location.
+* (Optional) `region = <string>` -> pass aws region. Defaults to `eu-west-1` if not set.
 
 ## Usage - GCP
 
@@ -95,7 +96,7 @@ EOF
   service account and scheduler job names to prevent naming conflicts
 * (Optional) `ckr_schedule = "0 10 * * 1-5"` -> Defaults to triggering 10am Monday-Friday.
 * (Optional) `ckr_schedule_time_zone = "Europe/London"` -> The time zone for the scheduler job. Defaults to Europe/London
-* (Optional) `deploying_accounts = ["serviceAccount:terraform@myproject.iam.gserviceaccount.com"]` -> Any accounts which 
-  will be deploying the CKR terraform but do not have the iam.serviceAccountUser permission for the whole project. This 
-  gives the supplied accounts iam.serviceAccountUser permissions for the Cloud Key Rotator service account which is 
+* (Optional) `deploying_accounts = ["serviceAccount:terraform@myproject.iam.gserviceaccount.com"]` -> Any accounts which
+  will be deploying the CKR terraform but do not have the iam.serviceAccountUser permission for the whole project. This
+  gives the supplied accounts iam.serviceAccountUser permissions for the Cloud Key Rotator service account which is
   necessary to deploy the terraform module. Defaults to an empty list

--- a/tf_module/ckr_aws/main.tf
+++ b/tf_module/ckr_aws/main.tf
@@ -119,14 +119,14 @@ resource "aws_iam_policy" "ckr_log_policy" {
                 "logs:PutLogEvents"
             ],
             "Resource": [
-                "arn:aws:logs:eu-west-1:${local.account_id}:log-stream:*:*:*",
-                "arn:aws:logs:eu-west-1:${local.account_id}:log-group:/aws/lambda/cloud-key-*"
+                "arn:aws:logs:${var.region}:${local.account_id}:log-stream:*:*:*",
+                "arn:aws:logs:${var.region}:${local.account_id}:log-group:/aws/lambda/cloud-key-*"
             ]
         },
         {
             "Effect": "Allow",
             "Action": "logs:CreateLogGroup",
-            "Resource": "arn:aws:logs:eu-west-1:${local.account_id}:*"
+            "Resource": "arn:aws:logs:${var.region}:${local.account_id}:*"
         }
     ]
 }
@@ -150,7 +150,7 @@ resource "aws_iam_policy" "ckr_ssm_policy" {
                 "ssm:PutParameter"
             ],
             "Resource": [
-                "arn:aws:ssm:eu-west-1:${local.account_id}:parameter/*"
+                "arn:aws:ssm:${var.region}:${local.account_id}:parameter/*"
             ]
         }
     ]

--- a/tf_module/ckr_aws/vars.tf
+++ b/tf_module/ckr_aws/vars.tf
@@ -17,3 +17,8 @@ variable "enable_ssm_location" {
 variable "ckr_trigger_description" {
   default = "Scheduled cloud key rotation"
 }
+
+variable "region" {
+  type    = string
+  default = "eu-west-1"
+}


### PR DESCRIPTION
International teams don't use eu-west-1 but we'd love to use this rotator to replace our existing janky python script. 

This PR allows users of the aws module to specify their own region but defaults to eu-west-1 if not set