### PR TITLE
Improve GCP module documentation and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ckr.yaml
 key.json
 .vscode
 tf_module/**/.terraform*
+curl_output

--- a/tf_module/README.md
+++ b/tf_module/README.md
@@ -92,7 +92,7 @@ EOF
 * `version = "0.2.0"` -> The Terraform module version to use.
 * `ckr_version = "0.27.29"` -> The Cloud Key Rotator binary version to use.
 * `ckr_config = <string>` -> Pass a json blob from any source containing your config file.
-* `ckr_resource_suffix = "my-project-name"` -> Will be appended to the bucket, cloud function, custom role
+* (Optional) `ckr_resource_suffix = "my-project-name"` -> Will be appended to the bucket, cloud function, custom role. Defaults to a 3 character random string
   service account and scheduler job names to prevent naming conflicts
 * (Optional) `ckr_schedule = "0 10 * * 1-5"` -> Defaults to triggering 10am Monday-Friday.
 * (Optional) `ckr_schedule_time_zone = "Europe/London"` -> The time zone for the scheduler job. Defaults to Europe/London

--- a/tf_module/ckr_gcp/vars.tf
+++ b/tf_module/ckr_gcp/vars.tf
@@ -1,20 +1,33 @@
+variable "ckr_version" {
+  type        = string
+  description = "The Cloud Key Rotator binary version to use."
+}
+
+variable "ckr_config" {
+  type        = string
+  description = "The JSON configuration for the Cloud Key Rotator to use"
+}
+
 variable "ckr_resource_suffix" {
-  default = ""
+  default     = ""
+  type        = string
+  description = "Suffix to append to resources to avoid naming conflicts if multiple cloud key rotator modules are in use in your project"
 }
 
 variable "ckr_schedule" {
-  default = "0 10 * * 1-5"
+  default     = "0 10 * * 1-5"
+  type        = string
+  description = "Cron style schedule at which to trigger the Cloud Key rotator"
 }
 
 variable "ckr_schedule_time_zone" {
-  default = "Europe/London"
+  default     = "Europe/London"
+  type        = string
+  description = "The time zone for the scheduler job to schedule in"
 }
 
 variable "deploying_accounts" {
-  default = []
-  type    = list(string)
+  default     = []
+  type        = list(string)
+  description = "List of accounts which will be deploying the CKR terraform. This needs to be given if you are not giving the deploying accounts the iam.serviceAccountUser permission for the whole project"
 }
-
-variable "ckr_version" {}
-
-variable "ckr_config" {}

--- a/tf_module/e2e_test/README.md
+++ b/tf_module/e2e_test/README.md
@@ -1,0 +1,7 @@
+# Terraform Module E2E Test
+
+This directory aims to provide a quick way to validate terraform module changes. The
+terraform in the e2e test creates the gcp cloud key rotator module with the minimum allowed
+inputs on the oldest permitted terraform version (0.12).
+
+Please use `terraform destroy` when you're done to remove the resources created during testing.

--- a/tf_module/e2e_test/main.tf
+++ b/tf_module/e2e_test/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  backend "gcs" {
+    bucket = "prod-eng-dev-terraform"
+    prefix = "ckr_e2e/"
+  }
+}
+
+provider "google" {
+  project = "pe-dev-185509"
+  region  = "europe-west3"
+}
+
+module "cloud-key-rotator" {
+  source      = "../ckr_gcp"
+  ckr_version = "0.27.34"
+  ckr_config  = <<EOF
+  {
+    "EnableKeyAgeLogging": true,
+    "RotationMode": false
+  }
+  EOF
+}


### PR DESCRIPTION
I made a cloud key rotator terraform module update a few weeks ago and it was a bit of a faff validating the change. In order to make it easier next time, I've created a minimal e2e terraform configuration to use for testing. It would be great to include applying that module and then cleaning it up as part of the circleCI merge to master workflow, but I've left it as just this for now.

I've also added descriptions to the variables to try to make the module easier to use and fixed a bug where if you didn't specify cloud-key-rotator suffix, GCP errored because the account name was "ckr-".