### PR TITLE
Add aws e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
               aws secretsmanager get-secret-value --secret-id ckr-config --region eu-west-1 --query SecretString --output text > config.json
               ./cloud-key-rotator rotate
               rm config.json
+              sleep 10
               if $(aws sts get-caller-identity >/dev/null 2>/dev/null); then exit 1; fi
   
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
             name: run rotate
             command: |
               export GO111MODULE=on
-              go build
+              go build -o cloud-key-rotator
               export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_E2E_TEST
               export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_E2E_TEST
               aws secretsmanager get-secret-value --secret-id ckr-config --region eu-west-1 --query SecretString --output text > config.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,14 +178,10 @@ jobs:
       - checkout
 
       - run:
-           name: go build
-           command: |
-             export GO111MODULE=on
-             go build
-
-      - run:
             name: run rotate
             command: |
+              export GO111MODULE=on
+              go build
               export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_E2E_TEST
               export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_E2E_TEST
               aws secretsmanager get-secret-value --secret-id ckr-config --region eu-west-1 --query SecretString --output text > config.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
             name: run rotate
             command: |
               export GO111MODULE=on
-              go build -o cloud-key-rotator
+              go build -o cloud-key-rotator ./cmd
               chmod u+x cloud-key-rotator
               export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_E2E_TEST
               export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_E2E_TEST

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
               aws secretsmanager get-secret-value --secret-id ckr-config --region eu-west-1 --query SecretString --output text > config.json
               ./cloud-key-rotator rotate
               rm config.json
+              if $(aws sts get-caller-identity >/dev/null 2>/dev/null); then exit 1; fi
   
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,7 @@ jobs:
             command: |
               export GO111MODULE=on
               go build -o cloud-key-rotator
+              chmod u+x cloud-key-rotator
               export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_E2E_TEST
               export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_E2E_TEST
               aws secretsmanager get-secret-value --secret-id ckr-config --region eu-west-1 --query SecretString --output text > config.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,30 @@ jobs:
              export GO111MODULE=on
              go mod download
              go test ./... -v
+
+  e2e_test_aws:
+    <<: *defaults
+
+    docker:
+      - image: eversc/aws-cli
+
+    steps:
+      - checkout
+
+      - run:
+           name: go build
+           command: |
+             export GO111MODULE=on
+             go build
+
+      - run:
+            name: run rotate
+            command: |
+              export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_E2E_TEST
+              export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_E2E_TEST
+              aws secretsmanager get-secret-value --secret-id ckr-config --region eu-west-1 --query SecretString --output text > config.json
+              ./cloud-key-rotator rotate
+              rm config.json
   
 
 workflows:
@@ -193,74 +217,19 @@ workflows:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
             branches:
               ignore: /.*/
-  pr_pipeline:
+  commits:
     jobs:
-      - go_fmt:
-          filters:
-            branches:
-              ignore: master
-      - go_vet:
-          filters:
-            branches:
-              ignore: master
-      - go_cyclo:
-          filters:
-            branches:
-              ignore: master
-      - go_lint:
-          filters:
-            branches:
-              ignore: master
-      - go_build:
-          filters:
-            branches:
-              ignore: master
-      - go_test:
-          filters:
-            branches:
-              ignore: master
-      - tf_check_aws:
-          filters:
-            branches:
-              ignore: master
-      - tf_check_gcp:
-          filters:
-            branches:
-              ignore: master
+      - go_fmt
+      - go_vet
+      - go_cyclo
+      - go_lint
+      - go_build
+      - go_test
+      - e2e_test_aws
+      - tf_check_aws
+      - tf_check_gcp
   master_pipeline:
     jobs:
-      - go_fmt:
-          filters:
-            branches:
-              only: master
-      - go_vet:
-          filters:
-            branches:
-              only: master
-      - go_cyclo:
-          filters:
-            branches:
-              only: master
-      - go_lint:
-          filters:
-            branches:
-              only: master
-      - go_build:
-          filters:
-            branches:
-              only: master
-      - go_test:
-          filters:
-            branches:
-              only: master
-      - tf_check_aws:
-          filters:
-            branches:
-              only: master
-      - tf_check_gcp:
-          filters:
-            branches:
-              only: master
       - publish_tf_module:
           filters:
             branches:

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -11,7 +11,7 @@ CircleCI:
   "RotationMode": true,
   "CloudProviders": [
     {
-      "Name": "aws",
+      "Name": "aws"
     }
   ],
   "AccountFilter": {


### PR DESCRIPTION
this PR adds a `e2e_test_aws` job to CircleCI

the job itself builds the cloud-key-rotator binary, downloads some config from AWS, then runs the binary with the `rotate` cmd

I also de-duped the workflow section in the CircleCI config. Separate (but virtually identical) workflows had been defined with "ignore: master" and "only:master"