### PR TITLE
Add GCP CloudFunction deploy test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,25 +11,17 @@ aliases:
     run:
       name: Deploy GCP Cloudfunction
       command: |
+        export RAND_SUFFIX=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo '')
         gcloud functions deploy ckr-dummy-$RAND_SUFFIX \
         --region europe-west1 \
         --entry-point Request \
         --runtime go113 \
         --trigger-http \
         --project pe-dev-185509
-  - &delete-cloudfunction
-    run:
-      name: Delete GCP Cloudfunction
-      command: |
         gcloud functions delete ckr-dummy-$RAND_SUFFIX \
         --region europe-west1 \
-        --project pe-dev-185509
-      background: true
-  - &rand-string
-    run:
-      name: Generate random string
-      command: |
-        echo "export RAND_SUFFIX=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo '')" >> $BASH_ENV
+        --project pe-dev-185509 \
+        --quiet
 
 defaults: &defaults
   working_directory: /go/src/github.com/ovotech/cloud-key-rotator
@@ -235,9 +227,7 @@ jobs:
     steps:
       - checkout
       - <<: *init-credentials
-      - <<: *rand-string
       - <<: *deploy-cloudfunction
-      - <<: *delete-cloudfunction
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,22 @@
+aliases:
+  - &docker-image
+    docker:
+      - image: google/cloud-sdk
+  - &init-credentials
+    run:
+      name: Get credentials
+      command: |
+        echo $GCLOUD_SERVICE_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
+  - &deploy-cloudfunction
+    run:
+      name: Deploy GCP Cloudfunction
+      command: |
+        gcloud functions deploy ckr-dummy --region europe-west1 \
+        --entry-point Request \
+        --runtime go113 \
+        --trigger-http \
+        --project pe-dev-185509
+
 defaults: &defaults
   working_directory: /go/src/github.com/ovotech/cloud-key-rotator
 
@@ -195,7 +214,14 @@ jobs:
               rm config.json
               sleep 10
               if $(aws sts get-caller-identity >/dev/null 2>/dev/null); then exit 1; fi
-  
+
+# required due to previous builds failing only in GCP CloudFunctions (while building directly with Go works...)
+  test_cloudfunction_deploy:
+    <<: *docker-image
+    steps:
+      - checkout
+      - <<: *init-credentials
+      - <<: *deploy-cloudfunction
 
 workflows:
   version: 2
@@ -232,6 +258,7 @@ workflows:
       - e2e_test_aws
       - tf_check_aws
       - tf_check_gcp
+      - test_cloudfunction_deploy
   master_pipeline:
     jobs:
       - publish_aws_tf_module:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,25 @@ aliases:
     run:
       name: Deploy GCP Cloudfunction
       command: |
-        export rand_suffix=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo '')
-        gcloud functions deploy ckr-dummy-$rand_suffix \
+        gcloud functions deploy ckr-dummy-$RAND_SUFFIX \
         --region europe-west1 \
         --entry-point Request \
         --runtime go113 \
         --trigger-http \
         --project pe-dev-185509
-        gcloud functions delete ckr-dummy-$rand_suffix \
+  - &delete-cloudfunction
+    run:
+      name: Delete GCP Cloudfunction
+      command: |
+        gcloud functions delete ckr-dummy-$RAND_SUFFIX \
         --region europe-west1 \
-        --project pe-dev-185509 &
+        --project pe-dev-185509
+      background: true
+  - &rand-string
+    run:
+      name: Generate random string
+      command: |
+        echo "export RAND_SUFFIX=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo '')" >> $BASH_ENV
 
 defaults: &defaults
   working_directory: /go/src/github.com/ovotech/cloud-key-rotator
@@ -226,7 +235,9 @@ jobs:
     steps:
       - checkout
       - <<: *init-credentials
+      - <<: *rand-string
       - <<: *deploy-cloudfunction
+      - <<: *delete-cloudfunction
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,16 @@ aliases:
     run:
       name: Deploy GCP Cloudfunction
       command: |
-        gcloud functions deploy ckr-dummy --region europe-west1 \
+        export rand_suffix=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 8 ; echo '')
+        gcloud functions deploy ckr-dummy-$rand_suffix \
+        --region europe-west1 \
         --entry-point Request \
         --runtime go113 \
         --trigger-http \
         --project pe-dev-185509
+        gcloud functions delete ckr-dummy-$rand_suffix \
+        --region europe-west1 \
+        --project pe-dev-185509 &
 
 defaults: &defaults
   working_directory: /go/src/github.com/ovotech/cloud-key-rotator


### PR DESCRIPTION
This adds a test to CI/CD that deploys the code to a dummy GCP cloudfunction

Due to a strange issue encountered when bumping the version of `spf13/viper`, deploys of the code to GCP cloudfunctions started failing with:

```
Error: Error waiting for Updating CloudFunctions Function: Error code 3, message: Build failed: github.com/ovotech/cloud-key-rotator/pkg/config imports
	github.com/spf13/viper imports
	github.com/spf13/afero imports
	io/fs: cannot find module providing package io/fs
github.com/ovotech/cloud-key-rotator/pkg/config imports
	github.com/spf13/viper imports
	github.com/spf13/afero tested by
	github.com/spf13/afero.test imports
	testing/fstest: cannot find module providing package testing/fstest; Error ID: 32633c29
```

..while `go build` locally worked fine..

I never tracked down the root cause, I just downgraded `viper` and cut a new release. Hopefully this CI/CD check will help prevent that from happening again.