### PR TITLE
Increase dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: monthly
+    interval: daily
   open-pull-requests-limit: 10
   reviewers:
   - eversC


### PR DESCRIPTION
this should help reduce the risk of e2e tests (which involve the creation of access keys) clashing between multiple PRs