### PR TITLE
Revert CircleCI CI/CD image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
     <<: *defaults
 
     docker:
-      - image: cimg/go:1.13
+      - image: circleci/golang:1.13
 
     steps:
       - checkout


### PR DESCRIPTION
seeing this error with the new image:

```
mkdir: cannot create directory ‘/go’: Permission denied

exit status 1
```
https://app.circleci.com/pipelines/github/ovotech/cloud-key-rotator/1234/workflows/ad711739-a1fe-4cab-b217-51f92fbfe8e8/jobs/8617