### PR TITLE
Revert "Bump alpine base from 3.15.4 to 3.15.6"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.6
+FROM alpine:3.15.4
 
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This reverts commit 2acc9c0be01b795a0e8271bf6245e3d82171d3c5.