### PR TITLE
Document the Base64Decode circleci parameter

### DIFF
--- a/examples/locations/circleci-contexts/README.md
+++ b/examples/locations/circleci-contexts/README.md
@@ -65,3 +65,17 @@ When rotating GCP keys, to override the default CircleCI env var name
       "KeyEnvVar": "GCP_KEY"
     }]
 ```
+
+If you use a GCP key to interact with GCR, especially for downloading
+docker images for CircleCI to run your pipelines, then you may want the
+key to be stored as JSON directly, rather than base64 encoded (which is
+the default). You can do this easily by setting the `Base64Decode` option
+to true in the CircleCI location block, like so:
+
+```json
+    "CircleCI": [{
+      "ContextID": "my-uuid-context-id",
+      "Base64Decode": true
+    }]
+```
+

--- a/examples/locations/circleci/README.md
+++ b/examples/locations/circleci/README.md
@@ -61,3 +61,17 @@ the key, is needed for GCP)
       "KeyEnvVar": "GCP_KEY"
     }]
 ```
+
+If you use a GCP key to interact with GCR, especially for downloading
+docker images for CircleCI to run your pipelines, then you may want the
+key to be stored as JSON directly, rather than base64 encoded (which is
+the default). You can do this easily by setting the `Base64Decode` option
+to true in the CircleCI location block, like so:
+
+```json
+    "CircleCI": [{
+      "UsernameProject": "my_org/my_repo",
+      "Base64Decode": true
+    }]
+```
+


### PR DESCRIPTION
It was absolutely necessary for our particular use-case (which is
hosting the runner images in GCR), but I encountered it only because I
went into the code to see how easy it would be to change a couple of
things we needed. This was one of them, and the most important, so it
was a pleasant surprise to find it!