### PR TITLE
Validate config from AWS SSM

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,9 @@ func GetConfigFromAWSSecretManager(secretName, configType string) (c Config, err
 		return c, errors.New("Unable to obtain secret value. Check user permissions and secret name")
 	}
 	viper.SetConfigType(configType)
-	viper.ReadConfig(bytes.NewBufferString(secret))
+	if err = viper.ReadConfig(bytes.NewBufferString(secret)); err == nil {
+		return
+	}
 	err = viper.Unmarshal(&c)
 	return
 }


### PR DESCRIPTION
users were experiencing a run of the rotator when the config json was invalid

changes in this PR should catch that scenario and return an error